### PR TITLE
🐛 fix: prevents background scroll on mobile modal

### DIFF
--- a/src/components/MainContent.vue
+++ b/src/components/MainContent.vue
@@ -144,6 +144,7 @@ export default {
       this.scrollY = window.scrollY
       this.loadingDetails = true
       this.openModal = true
+      document.body.style.overflow = 'hidden'
 
       try {
         const newMovie = await getById(movie.id)
@@ -157,6 +158,7 @@ export default {
 
     handleCloseModal() {
       this.openModal = false
+      document.body.style.overflow = 'auto'
 
       this.$nextTick(() => {
         window.scrollTo(0, this.scrollY)


### PR DESCRIPTION
## Description
Fixes an issue where the background page could still scroll when the movie modal was open on mobile devices.

## Changes
- Added scroll lock when modal opens
- Restored scroll when modal closes

## Notes
Tested on mobile and desktop