### PR TITLE
🐛 fix: ensure modal opens from top when page is scrolled

### DIFF
--- a/src/components/MainContent.vue
+++ b/src/components/MainContent.vue
@@ -142,6 +142,8 @@ export default {
 
     async expandMovie(movie: MovieCard) {
       this.scrollY = window.scrollY
+      window.scrollTo(0, 0)
+
       this.loadingDetails = true
       this.openModal = true
       document.body.style.overflow = 'hidden'


### PR DESCRIPTION
## Description
Fixes an issue where the modal could open partially when the page was scrolled.

## Changes
- Saved current scroll position before opening modal
- Reset scroll to top when modal opens
- Restored scroll position when modal closes