### PR TITLE
🐛 fix: corretcs upcoming movies filtering by release date

### DIFF
--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -26,7 +26,15 @@ export async function getTopRated(page: number, filter?: FilterData) {
 }
 
 export async function getUpComing(page: number, filter?: FilterData) {
-  const response = await tmdb.get(`/movie/upcoming?page=${page}`)
+  const today = new Date().toISOString().split('T')[0]
+
+  const response = await tmdb.get(`discover/movie?page=${page}`, {
+    params: {
+      page,
+      'primary_release_date.gte': today,
+      sort_by: 'popularity.desc',
+    },
+  })
   const upcomingMovies: MovieCardData = response.data
 
   return upcomingMovies


### PR DESCRIPTION
## Description
Fixes an issue where the Upcoming movies section was displaying outdated or incorrect results due to reliance on the `/movie/upcoming` endpoint.

## Changes
- Replaced `/movie/upcoming` endpoint with `/discover/movie`
- Added `primary_release_date.gte` filter based on current date
- Updated sorting to `primary_release_date.asc` to ensure proper chronological order

## ✅ Issue
Closes #22 