### PR TITLE
🐛 fix: resets selected movie when closing modal

### DIFF
--- a/src/components/MainContent.vue
+++ b/src/components/MainContent.vue
@@ -228,6 +228,7 @@ export default {
     handleCloseModal() {
       this.openModal = false
       document.body.style.overflow = 'auto'
+      this.selectedMovie = {} as MovieCard
 
       this.$nextTick(() => {
         window.scrollTo(0, this.scrollY)


### PR DESCRIPTION
## Description

Fixes an issue where the movie details modal would not reopen correctly after being closed.

## Changes

- Reset selected movie when closing modal
- Ensure modal state updates correctly when reopening the same movie

## Issue

Closes #26 