### PR TITLE
🐛 fix: adds fallback img to the featured banner

### DIFF
--- a/src/components/FeaturedMovie.vue
+++ b/src/components/FeaturedMovie.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import fallbackImg from '@/assets/images/no-poster.png'
 import { genreMap } from '@/constants/genres'
 import { getFeaturedMovies } from '@/http'
 import type { MovieCard } from '@/interfaces/MovieCardData'
@@ -39,8 +40,23 @@ export default {
   },
 
   methods: {
-    getImgUrl(path: string) {
-      return `https://image.tmdb.org/t/p/original${path}`
+    getBackdropImg(movie: MovieCard) {
+      if (movie.backdrop_path) {
+        return `https://image.tmdb.org/t/p/original${movie.backdrop_path}`
+      } else if (movie.poster_path) {
+        return `https://image.tmdb.org/t/p/original${movie.poster_path}`
+      } else {
+        return fallbackImg
+      }
+    },
+    getPosterImg(movie: MovieCard) {
+      if (movie.poster_path) {
+        return `https://image.tmdb.org/t/p/original${movie.poster_path}`
+      } else if (movie.backdrop_path) {
+        return `https://image.tmdb.org/t/p/original${movie.backdrop_path}`
+      } else {
+        return fallbackImg
+      }
     },
     getGenreName(id: number) {
       return genreMap[id] || 'Unknown'
@@ -55,9 +71,10 @@ export default {
     class="relative w-full overflow-hidden rounded-xl"
   >
     <picture>
+      <source media="(min-width: 1024px)" :srcset="getBackdropImg(movie)" />
       <img
         class="rounded-xl object-cover w-full h-[400px] sm:h-[500px] md:h-[600px]"
-        :src="getImgUrl(movie?.backdrop_path)"
+        :src="getPosterImg(movie)"
         :alt="`Imagem do filme ` + movie?.title"
       />
     </picture>

--- a/src/components/MovieDetailsModal.vue
+++ b/src/components/MovieDetailsModal.vue
@@ -154,11 +154,7 @@ export default {
       ></div>
 
       <picture>
-        <source
-          media="(min-width: 1024px)"
-          :srcset="getBackdropImg(movie)"
-          class=""
-        />
+        <source media="(min-width: 1024px)" :srcset="getBackdropImg(movie)" />
         <img
           :key="movie?.id"
           class="h-full w-full object-cover"


### PR DESCRIPTION
## Description

Fixes missing images in the featured movie banner when TMDB results do not provide a `backdrop_path` or `poster_path`.

## Changes

- Add fallback logic for featured movie images
- Use poster image when backdrop is unavailable
- Fallback to placeholder image when no image is available
- Align FeaturedMovie image behavior with MovieDetailsModal

## Issue 

Closes #30 