### PR TITLE
✨ feat: adds collapsible filter panel for mobile screens

### DIFF
--- a/src/components/SidebarFilters.vue
+++ b/src/components/SidebarFilters.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
 import type FilterData from '@/interfaces/FilterData'
+import { ChevronDown, ChevronUp } from 'lucide-vue-next'
 
 export default {
+  components: { ChevronDown, ChevronUp },
   emits: ['update:search'],
-
   data() {
     return {
       search: {
@@ -13,6 +14,7 @@ export default {
         toYear: '',
       } as FilterData,
       debounce: 0,
+      isOpen: false,
     }
   },
 
@@ -23,6 +25,15 @@ export default {
       },
       deep: true,
     },
+  },
+
+  mounted() {
+    this.checkScreen()
+    window.addEventListener('resize', this.checkScreen)
+  },
+
+  beforeUnmount() {
+    window.removeEventListener('resize', this.checkScreen)
   },
 
   methods: {
@@ -41,111 +52,144 @@ export default {
         this.$emit('update:search', this.search)
       }, 300)
     },
+    expandSideBar() {
+      this.isOpen = !this.isOpen
+    },
+    checkScreen() {
+      if (window.innerWidth >= 1024) {
+        this.isOpen = true
+      }
+    },
   },
 }
 </script>
-
 <template>
-  <aside class="p-4 md:p-6 lg-p-8 flex flex-col gap-6">
-    <h3 class="text-primaryHeading font-bold text-2xl">Filters</h3>
+  <aside
+    id="sidebar-filters"
+    aria-label="Filtros de busca"
+    :aria-hidden="!isOpen"
+    :class="isOpen ? 'max-h-[400px] opacity-100' : 'max-h-0 opacity-0'"
+    class="overflow-hidden transition-all duration-500 ease-linear"
+  >
+    <div class="p-4 md:p-6 lg-p-8 flex flex-col gap-6">
+      <h3 class="text-primaryHeading font-bold text-2xl">Filters</h3>
 
-    <section>
-      <label for="title" class="text-primaryHeading mb-2 block">Title</label>
-      <input
-        id="title"
-        v-model="search.title"
-        type="text"
-        placeholder="Type the title of the movie"
-        class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800"
-      />
-    </section>
+      <section>
+        <label for="title" class="text-primaryHeading mb-2 block">Title</label>
+        <input
+          id="title"
+          v-model="search.title"
+          type="text"
+          placeholder="Type the title of the movie"
+          class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800"
+        />
+      </section>
 
-    <section>
-      <label for="genre" class="text-primaryHeading mb-2 block">Genre</label>
+      <section>
+        <label for="genre" class="text-primaryHeading mb-2 block">Genre</label>
 
-      <div class="grid grid-cols-1">
-        <select
-          id="genre"
-          v-model="search.genre"
-          class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800 col-start-1 row-start-1 appearance-none"
-        >
-          <option value="all">All</option>
-          <option value="28">Action</option>
-          <option value="12">Adventure</option>
-          <option value="16">Animation</option>
-          <option value="35">Comedy</option>
-          <option value="80">Crime</option>
-          <option value="99">Documentary</option>
-          <option value="18">Drama</option>
-          <option value="10751">Family</option>
-          <option value="14">Fantasy</option>
-          <option value="36">History</option>
-          <option value="27">Horror</option>
-          <option value="10402">Music</option>
-          <option value="9648">Mystery</option>
-          <option value="10749">Romance</option>
-          <option value="878">Science Fiction</option>
-          <option value="10770">TV Movie</option>
-          <option value="53">Thriller</option>
-          <option value="10752">War</option>
-          <option value="37">Western</option>
-        </select>
-        <svg
-          viewBox="0 0 16 16"
-          fill="currentColor"
-          data-slot="icon"
-          aria-hidden="true"
-          class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-primaryHeading sm:size-4"
-        >
-          <path
-            d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
-            clip-rule="evenodd"
-            fill-rule="evenodd"
+        <div class="grid grid-cols-1">
+          <select
+            id="genre"
+            v-model="search.genre"
+            class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800 col-start-1 row-start-1 appearance-none"
+          >
+            <option value="all">All</option>
+            <option value="28">Action</option>
+            <option value="12">Adventure</option>
+            <option value="16">Animation</option>
+            <option value="35">Comedy</option>
+            <option value="80">Crime</option>
+            <option value="99">Documentary</option>
+            <option value="18">Drama</option>
+            <option value="10751">Family</option>
+            <option value="14">Fantasy</option>
+            <option value="36">History</option>
+            <option value="27">Horror</option>
+            <option value="10402">Music</option>
+            <option value="9648">Mystery</option>
+            <option value="10749">Romance</option>
+            <option value="878">Science Fiction</option>
+            <option value="10770">TV Movie</option>
+            <option value="53">Thriller</option>
+            <option value="10752">War</option>
+            <option value="37">Western</option>
+          </select>
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            data-slot="icon"
+            aria-hidden="true"
+            class="pointer-events-none col-start-1 row-start-1 mr-2 size-5 self-center justify-self-end text-primaryHeading sm:size-4"
+          >
+            <path
+              d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z"
+              clip-rule="evenodd"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+      </section>
+
+      <fieldset>
+        <legend class="text-primaryHeading mb-2">Release date</legend>
+
+        <div class="flex flex-row gap-2 w-full">
+          <label for="fromYear" class="sr-only">From year</label>
+          <input
+            id="fromYear"
+            v-model="search.fromYear"
+            placeholder="YYYY"
+            inputmode="numeric"
+            type="text"
+            maxlength="4"
+            pattern="^(19|20)\d{2}$"
+            class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800"
           />
-        </svg>
-      </div>
-    </section>
 
-    <fieldset>
-      <legend class="text-primaryHeading mb-2">Release date</legend>
+          <span class="text-primaryHeading" aria-hidden="true">_</span>
 
-      <div class="flex flex-row gap-2 w-full">
-        <label for="fromYear" class="sr-only">From year</label>
-        <input
-          id="fromYear"
-          v-model="search.fromYear"
-          placeholder="YYYY"
-          inputmode="numeric"
-          type="text"
-          maxlength="4"
-          pattern="^(19|20)\d{2}$"
-          class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800"
-        />
+          <label for="toYear" class="sr-only">To year</label>
+          <input
+            id="toYear"
+            v-model="search.toYear"
+            placeholder="YYYY"
+            inputmode="numeric"
+            type="text"
+            maxlength="4"
+            pattern="^(19|20)\d{2}$"
+            class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800"
+          />
+        </div>
+      </fieldset>
 
-        <span class="text-primaryHeading" aria-hidden="true">_</span>
-
-        <label for="toYear" class="sr-only">To year</label>
-        <input
-          id="toYear"
-          v-model="search.toYear"
-          placeholder="YYYY"
-          inputmode="numeric"
-          type="text"
-          maxlength="4"
-          pattern="^(19|20)\d{2}$"
-          class="text-primaryHeading border border-white rounded-md w-full py-1 px-2 bg-gray-800"
-        />
-      </div>
-    </fieldset>
-
-    <section>
-      <button
-        type="button"
-        class="text-primaryHeading border w-full py-2 rounded-md hover:bg-primaryText hover:text-secondaryHeading transition-colors duration-300"
-        @click="resetFilters"
-      >
-        Reset Filters
-      </button>
-    </section>
+      <section>
+        <button
+          type="button"
+          class="text-primaryHeading border w-full py-2 rounded-md hover:bg-primaryText hover:text-secondaryHeading transition-colors duration-300"
+          @click="resetFilters"
+        >
+          Reset Filters
+        </button>
+      </section>
+    </div>
   </aside>
+
+  <button
+    type="button"
+    :aria-expanded="isOpen"
+    aria-controls="sidebar-filters"
+    class="flex flex-col justify-center items-center mt-3 cursor-pointer m-auto lg:hidden"
+    @click="expandSideBar"
+  >
+    <div v-show="!isOpen" class="flex flex-col items-center">
+      <span class="text-primaryText text-fs-1">Abrir filtros</span>
+      <ChevronDown aria-hidden="true" class="text-primaryText"></ChevronDown>
+    </div>
+
+    <div v-show="isOpen" class="flex flex-col items-center">
+      <span class="text-primaryText text-fs-1">Fechar</span>
+      <ChevronUp aria-hidden="true" class="text-primaryText"></ChevronUp>
+    </div>
+  </button>
 </template>


### PR DESCRIPTION
## Description

On mobile screens, the filter panel was always visible, taking up unnecessary space. This PR adds a toggle button to collapse and expand the filters panel on smaller screens.

## Changes

- Added `isOpen` state to control sidebar visibility
- Added toggle button with `ChevronDown`/`ChevronUp` icons, visible only on mobile (`lg:hidden`)
- Sidebar collapses with smooth `max-h` + `opacity` transition on mobile
- Sidebar stays expanded on desktop, adjusting correctly on window resize
- Added accessibility attributes: `aria-expanded`, `aria-controls`, `aria-hidden` and `aria-label`


## Issue

Closes #38 