### PR TITLE
✨ feat: replaces native select with accessible custom dropdown

### DIFF
--- a/src/components/CardMovie.vue
+++ b/src/components/CardMovie.vue
@@ -40,7 +40,7 @@ export default {
     <section class="relative aspect-2/3">
       <div
         v-show="imgState == 'loading'"
-        class="absolute inset-0 shimmer z-10"
+        class="absolute inset-0 shimmer"
       ></div>
       <img
         v-show="imgState !== 'loading'"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -8,9 +8,98 @@ export default {
     return {
       countries: [] as CountryData[],
       regionStore,
+      selectedDropdown: '',
+      isDropDownOpen: false,
+      focusedCountryId: '',
+      focusedCountryIndex: -1,
+      handleClick: null as null | ((e: MouseEvent) => void),
+      handleKeyDown: null as null | ((e: KeyboardEvent) => void),
     }
   },
+  watch: {
+    isDropDownOpen() {
+      document.body.style.overflowY = this.isDropDownOpen ? 'hidden' : 'auto'
+    },
+  },
+  mounted() {
+    this.handleClick = (e: MouseEvent) => {
+      const select = this.$refs.countrySelect as HTMLDivElement
 
+      if (!select) return
+
+      const target = e.target
+      if (!(target instanceof Node)) return
+
+      if (!select.contains(target)) {
+        this.isDropDownOpen = false
+      }
+    }
+
+    this.handleKeyDown = (e: KeyboardEvent) => {
+      const select = this.$refs.countrySelect as HTMLDivElement
+      const btn_menu = this.$refs.btn_menu as HTMLButtonElement
+
+      if (!select) return
+      if (!this.isDropDownOpen) return
+
+      const target = e.target
+      if (!(target instanceof Node)) return
+
+      if (e.key === 'Escape') {
+        this.isDropDownOpen = false
+
+        if (!btn_menu) return
+
+        btn_menu.focus()
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+
+        let prevIndex = this.focusedCountryIndex - 1
+
+        if (prevIndex < 0) {
+          prevIndex = this.countries.length - 1
+        }
+
+        const li = document.getElementById(this.countries[prevIndex].iso_3166_1)
+
+        if (li) {
+          li.focus()
+        }
+      }
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+
+        let nextIndex = this.focusedCountryIndex + 1
+
+        if (nextIndex > this.countries.length - 1) {
+          nextIndex = 0
+        }
+
+        const li = document.getElementById(this.countries[nextIndex].iso_3166_1)
+
+        if (li) {
+          li.focus()
+        }
+      }
+    }
+
+    document.addEventListener('click', this.handleClick)
+    document.addEventListener('keydown', this.handleKeyDown)
+  },
+  unmounted() {
+    const select = this.$refs.countrySelect as HTMLDivElement
+
+    if (select && this.handleClick) {
+      document.removeEventListener('click', this.handleClick)
+    }
+
+    if (this.handleKeyDown) {
+      document.removeEventListener('keydown', this.handleKeyDown)
+    }
+  },
   async created() {
     try {
       const countries = await getCountriesList()
@@ -19,35 +108,123 @@ export default {
       console.error('Erro ao buscar países:', error)
     }
   },
+  methods: {
+    setSelectedItem(item: string) {
+      this.regionStore.region = item
+      this.isDropDownOpen = false
+
+      window.scrollTo(0, 0)
+
+      const btn_menu = this.$refs.btn_menu as HTMLButtonElement
+
+      if (!btn_menu) return
+
+      btn_menu.focus()
+    },
+    async toggleDrop() {
+      this.isDropDownOpen = !this.isDropDownOpen
+
+      if (this.isDropDownOpen) {
+        await this.$nextTick()
+        const selected = this.$el.querySelector('input[type="radio"]:checked')
+        const li = this.$el.querySelector('li[aria-selected="true"]')
+
+        if (selected) {
+          selected.scrollIntoView({ block: 'center' })
+        }
+
+        if (li) {
+          li.focus()
+        }
+      }
+    },
+  },
 }
 </script>
 
 <template>
   <header
-    class="sticky flex justify-between items-center p-8 top-0 z-100 bg-gray-900/80 backdrop-blur-sm border-b text-white"
+    class="sticky flex justify-between items-center p-8 top-0 z-10 bg-gray-900/80 backdrop-blur-sm border-b text-white"
   >
     <h1 class="text-2xl font-bold">CineVue</h1>
-    <div class="flex border border-white rounded-md py-1 px-2 cursor-pointer">
-      <span
-        class="fi mr-2"
-        :class="`fi-${regionStore.region.toLowerCase()}`"
-      ></span>
-      <select
-        id="country"
-        v-model="regionStore.region"
-        translate="no"
-        class="text-primaryHeading e outline-none cursor-pointer"
+
+    <div ref="countrySelect" class="relative">
+      <button
+        ref="btn_menu"
+        class="flex items-center gap-2 py-1 px-2 border rounded-md"
+        type="button"
+        data-toggle="dropdown"
+        :aria-expanded="isDropDownOpen"
+        aria-haspopup="listbox"
+        @click="toggleDrop"
       >
-        <option
-          v-for="country in countries"
-          :key="country.iso_3166_1"
-          class="bg-gray-800"
-          :value="country.iso_3166_1"
-          translate="no"
+        <span
+          class="fi mr-2"
+          :class="`fi-${regionStore.region.toLowerCase()}`"
+        ></span>
+        {{ regionStore.region }}
+        <svg
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          data-slot="icon"
+          aria-hidden="true"
+          class="-mr-1 size-5 text-primaryHeading"
         >
-          {{ country.iso_3166_1 }}
-        </option>
-      </select>
+          <path
+            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+            clip-rule="evenodd"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
+
+      <ul
+        v-if="isDropDownOpen"
+        :aria-activedescendant="focusedCountryId"
+        role="listbox"
+        aria-label="Selecionar país"
+        class="bg-gray-800 mt-3 mb-3 border rounded-md p-3 flex flex-col gap-2 fixed top-0 inset-x-0 mx-auto w-[calc(100vw-2rem)] h-[calc(100vh-6rem)] md:absolute md:inset-x-auto md:right-0 md:top-10 md:w-96 overflow-y-scroll"
+      >
+        <li
+          v-for="(country, index) in countries"
+          :id="country.iso_3166_1"
+          :key="country.iso_3166_1"
+          tabindex="0"
+          role="option"
+          :aria-selected="country.iso_3166_1 === regionStore.region"
+          class="border-b cursor-pointer pb-3 pt-3 flex justify-between"
+          @focus="
+            ((focusedCountryId = country.iso_3166_1),
+            (focusedCountryIndex = index))
+          "
+          @click="setSelectedItem(country.iso_3166_1)"
+          @keydown.enter="
+            (e) => {
+              e.preventDefault()
+              setSelectedItem(country.iso_3166_1)
+            }
+          "
+          @keydown.space="
+            (e) => {
+              e.preventDefault()
+              setSelectedItem(country.iso_3166_1)
+            }
+          "
+        >
+          <label tabindex="-1" :for="country.english_name">
+            {{ country.english_name }}</label
+          >
+          <input
+            :id="`input-${country.iso_3166_1}`"
+            v-model="regionStore.region"
+            tabindex="-1"
+            type="radio"
+            name="country"
+            :value="country.iso_3166_1"
+            class="peer-checked/draft:text-sky-500"
+          />
+        </li>
+      </ul>
     </div>
   </header>
 </template>

--- a/src/components/MovieDetailsModal.vue
+++ b/src/components/MovieDetailsModal.vue
@@ -85,6 +85,7 @@ export default {
       const dialog = this.$refs.movieModal as HTMLDialogElement
 
       if (!dialog) return
+      if (!dialog.open) return
 
       if (e.key === 'Escape') {
         this.$emit('close')


### PR DESCRIPTION
## Description
Replaced the native `<select>` with a fully custom country dropdown to support 
displaying full country names in the list while keeping flag + ISO code in the 
collapsed state — something not achievable with a native select element.

## Changes
- Replaced `<select>/<option>` with custom `<button>` + `<ul>/<li>` (listbox pattern)
- Display full country name (`english_name`) in dropdown options
- Keep flag + ISO code in collapsed button state
- Fullscreen overlay on mobile, anchored dropdown on desktop
- Lock body scroll when open, restore on close
- Close on outside click via document click listener
- Keyboard navigation: ArrowUp/ArrowDown (with wrap around), Enter, Space, Escape
- Escape returns focus to toggle button; selection returns focus to toggle button
- Full ARIA support: `role="listbox"`, `role="option"`, `aria-expanded`, `aria-haspopup`, `aria-selected`, `aria-label`, `aria-activedescendant`

## Issue
Closes #40 